### PR TITLE
EE-995 - Corrected syntax, added default value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@ mysql_client_packages:
   - mysql-community-client
 
 mysql_install_server: false
+
+mysql_package_url: "https://dev.mysql.com/get/mysql80-community-release-el7-5.noarch.rpm"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for memoryleak.mysql
 - name: Install yum repository package.
   package:
-    name: {{ mysql_package_url }}
+    name: "{{ mysql_package_url }}"
     state: present
   tags: ['package', 'mysql']
 


### PR DESCRIPTION
Updated "mysql_package_url" default value to actual repository setup package from https://dev.mysql.com/downloads/repo/yum/